### PR TITLE
remove the simple-blog from the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "packages/chakra-theme",
     "packages/login-logout",
     "packages/related-products",
-    "packages/simple-blog",
     "packages/apollo-blog",
     "packages/file-upload",
     "packages/margin-calculator"

--- a/packages/related-products/lib/api.ts
+++ b/packages/related-products/lib/api.ts
@@ -1,9 +1,10 @@
 import { Client } from "@gadget-client/related-products-example";
+
+/**
+ * To test using public key: gsk-T3QgryDwWaxQd9gNEigXRbrTaL3pKyxE
+ */
 export const api = new Client({
   authenticationMode: {
-    apiKey: "gsk-T3QgryDwWaxQd9gNEigXRbrTaL3pKyxE",
-    // browserSession: {
-    //   storageType: typeof window == "undefined" ? BrowserSessionStorageType.Temporary : BrowserSessionStorageType.Durable,
-    // },
+    apiKey: process.env.API_KEY,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,14 +1683,7 @@
   dependencies:
     "@gadgetinc/api-client-core" "^0.4.4"
 
-"@gadget-client/simple-blog-example@^1.163.0":
-  version "1.163.0"
-  resolved "https://registry.gadget.dev/npm/_/tarball/645/644/223#80cb0b1a5e648ae16b16440df96997f5752ce2fb"
-  integrity sha1-gMsLGl5kiuFrFkQN+WmX9XUs4vs=
-  dependencies:
-    "@gadgetinc/api-client-core" "0.4.5"
-
-"@gadgetinc/api-client-core@0.4.10", "@gadgetinc/api-client-core@0.4.5", "@gadgetinc/api-client-core@0.4.6", "@gadgetinc/api-client-core@^0.4", "@gadgetinc/api-client-core@^0.4.4":
+"@gadgetinc/api-client-core@0.4.10", "@gadgetinc/api-client-core@0.4.6", "@gadgetinc/api-client-core@^0.4", "@gadgetinc/api-client-core@^0.4.4":
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/@gadgetinc/api-client-core/-/api-client-core-0.4.6.tgz#bad4a4422062c5729aa9458c5269a522432f05cf"
   integrity sha512-bfrcqTchMpnCDoF0vUaWklVM8WYkLU2uhP4DWGBrvihy2uznymf/Jmd+Ymo7rX850iaWAO8+d9Lkxj4sHRyRGQ==


### PR DESCRIPTION
It looks like `@gadget-client/simple-blog-example` has been deleted, so the install is failing when trying to build and run the example projects. Uninstalling the dependency from the workspace yarn lock and removing the project from the workspace allows us to build the other projects until the blog Gadget app is restored or rebuilt.

I'm also allowing for the use of a passed-in API_KEY for the related product demo so we can have quick deploys with Vercel. I will add the deploy button in a follow-up PR.