### PR TITLE
Revive the simple-blog-example project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,4 +4,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["packages/*/tsconfig.json"],
   },
+  rules: {
+    // suppress errors for missing 'import React' in files
+    "react/react-in-jsx-scope": "off",
+    // allow jsx syntax in js files (for next.js project)
+    "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx", ".ts", ".tsx"] }],
+  },
 };

--- a/packages/related-products/lib/api.ts
+++ b/packages/related-products/lib/api.ts
@@ -1,9 +1,10 @@
 import { Client } from "@gadget-client/related-products-example";
+
+/**
+  * To test using public key: gsk-T3QgryDwWaxQd9gNEigXRbrTaL3pKyxE
+  */
 export const api = new Client({
   authenticationMode: {
-    apiKey: "gsk-T3QgryDwWaxQd9gNEigXRbrTaL3pKyxE",
-    // browserSession: {
-    //   storageType: typeof window == "undefined" ? BrowserSessionStorageType.Temporary : BrowserSessionStorageType.Durable,
-    // },
+    apiKey: process.env.API_KEY,
   },
 });

--- a/packages/simple-blog/lib/PostsList.tsx
+++ b/packages/simple-blog/lib/PostsList.tsx
@@ -4,7 +4,6 @@ import { Select } from "@gadgetinc/api-client-core";
 import { useFindMany } from "@gadgetinc/react";
 import { dateFormat, theme } from "chakra-theme";
 import ChakraUIRenderer from "chakra-ui-markdown-renderer";
-import React from "react";
 import ReactMarkdown from "react-markdown";
 import { api } from "./api";
 
@@ -23,11 +22,11 @@ const PostCard = (props: { post: Select<Post, typeof PostSelection> }) => {
         {props.post.title}
       </Heading>
       <Text size="sm" color={useColorModeValue("gray.700", "gray.200")}>
-        Written by {props.post.author.name} on {dateFormat.format(props.post.createdAt)}
+        Written by {props.post.author?.name} on {dateFormat.format(props.post.createdAt)}
       </Text>
       <Box marginTop={3}>
         <ReactMarkdown components={ChakraUIRenderer(theme)} skipHtml>
-          {props.post.body.markdown}
+          {props.post.body?.markdown || ""}
         </ReactMarkdown>
       </Box>
     </Box>

--- a/packages/simple-blog/lib/api.ts
+++ b/packages/simple-blog/lib/api.ts
@@ -1,3 +1,10 @@
 import { Client } from "@gadget-client/simple-blog-example";
 
-export const api = new Client();
+/**
+ * To test using public key: gsk-fe7X4gHDWdpJtPDqfeL8wGqWMziYCcFf
+ */
+export const api = new Client({
+  authenticationMode: {
+    apiKey: process.env.API_KEY,
+  },
+});

--- a/packages/simple-blog/package.json
+++ b/packages/simple-blog/package.json
@@ -12,7 +12,7 @@
     "@chakra-ui/react": "^1.7.0",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",
-    "@gadget-client/simple-blog-example": "^1.163.0",
+    "@gadget-client/simple-blog-example": "^1.57.0",
     "@gadgetinc/react": "^0.2.2",
     "chakra-theme": "*",
     "chakra-ui-autocomplete": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1683,14 +1683,14 @@
   dependencies:
     "@gadgetinc/api-client-core" "^0.4.4"
 
-"@gadget-client/simple-blog-example@^1.163.0":
-  version "1.163.0"
-  resolved "https://registry.gadget.dev/npm/_/tarball/645/644/223#80cb0b1a5e648ae16b16440df96997f5752ce2fb"
-  integrity sha1-gMsLGl5kiuFrFkQN+WmX9XUs4vs=
+"@gadget-client/simple-blog-example@^1.57.0":
+  version "1.57.0"
+  resolved "https://registry.gadget.dev/npm/_/tarball/2757/4339/571#39d3a39aa3da0ac1474922260842606d66f20f27"
+  integrity sha1-OdOjmqPaCsFHSSImCEJgbWbyDyc=
   dependencies:
-    "@gadgetinc/api-client-core" "0.4.5"
+    "@gadgetinc/api-client-core" "0.6.8"
 
-"@gadgetinc/api-client-core@0.4.10", "@gadgetinc/api-client-core@0.4.5", "@gadgetinc/api-client-core@0.4.6", "@gadgetinc/api-client-core@^0.4", "@gadgetinc/api-client-core@^0.4.4":
+"@gadgetinc/api-client-core@0.4.10", "@gadgetinc/api-client-core@0.4.6", "@gadgetinc/api-client-core@0.6.8", "@gadgetinc/api-client-core@^0.4", "@gadgetinc/api-client-core@^0.4.4":
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/@gadgetinc/api-client-core/-/api-client-core-0.4.6.tgz#bad4a4422062c5729aa9458c5269a522432f05cf"
   integrity sha512-bfrcqTchMpnCDoF0vUaWklVM8WYkLU2uhP4DWGBrvihy2uznymf/Jmd+Ymo7rX850iaWAO8+d9Lkxj4sHRyRGQ==


### PR DESCRIPTION
- created a simple blog app in Gadget with some sample data and refreshed the Gadget client package
- lint rule exceptions to get rid of some unnecessary context warnings (will have a follow-up PR for getting the lint action to pass)
- allow for passed in API key to be used for the simple blog and related products projects