### PR TITLE
add lodash as an explicit dependency for the product quiz

### DIFF
--- a/packages/product-recommendations-quiz-app/product-quiz-ui/package.json
+++ b/packages/product-recommendations-quiz-app/product-quiz-ui/package.json
@@ -13,6 +13,7 @@
     "@gadgetinc/react": "^0.3.1",
     "@shopify/polaris": "^9.3.0",
     "dotenv": "^16.0.0",
+    "lodash": "^4.17.21",
     "next": "^12.1.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",


### PR DESCRIPTION
App was failing for clients, adding lodash as a dep is required as it is used throughout the product quiz ui