### PR TITLE
add golang example for gql request without client package

### DIFF
--- a/packages/go-read-write/README.md
+++ b/packages/go-read-write/README.md
@@ -1,0 +1,26 @@
+# Golang Read/Write Sample
+
+This is a small Go script that illustrates how you can read or write to Gadget's GraphQL API.
+
+Not using Go? You can still take a look at the code snippet to figure out how to send a request to your Gadget app's API.
+
+## Run the script
+
+You can test this out yourself by adding a model called **Foo** that has a number field **Bar** to any Gadget app. Make sure to add your Gadget application's app slug and API Key.
+
+You must have [Go installed](https://go.dev/doc/install). Then enter `go run .` into your terminal. You should see Foo values added to your Gadget app.
+
+You can also uncomment the _READ DATA (QUERY)_ section to try reading data (Foo.id = 1 by default) from your application.
+
+## Gadget concepts covered
+
+- How to request data from or write data to a Gadget app without using the generated API client npm package
+  - GraphQL query using automatically generated CRUD API
+  - Use of API Keys as a Bearer token
+
+## Learn more
+
+To learn more about Gadget:
+
+- [Gadget documentation](https://docs.gadget.dev) - learn about Gadget's features and connectivity
+- check out the Authentication and GraphQL sections of your Gadget project's API docs

--- a/packages/go-read-write/go.mod
+++ b/packages/go-read-write/go.mod
@@ -1,0 +1,3 @@
+module example/gadget
+
+go 1.19

--- a/packages/go-read-write/read-write-example.go
+++ b/packages/go-read-write/read-write-example.go
@@ -5,25 +5,37 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
 )
 
+// grab your project's API key from Settings -> API Keys in Gadget
+const (
+	GADGET_APP_SLUG = "<your-gadget-slug>"
+	GADGET_API_KEY  = "<your Gadget API key>"
+)
+
 func main() {
 	// READ DATA (QUERY)
+	// findMany foos
 	// jsonData := map[string]string{
 	//     "query": `
-	//         { 
-	//             foo(id: 1) {
-	//                 id,
-	//                 bar
-	//             }
-	//         }
+	// 			{
+	// 				foos {
+	// 					edges {
+	// 						node {
+	// 							id
+	// 							bar
+	// 						}
+	// 					}
+	// 				}
+	// 			}
 	//     `,
 	// }
 
-
 	// WRITE DATA (MUTATION)
+	// creates a new Foo with bar field set to 1
 	jsonData := map[string]interface{}{
 		"query": `
 			mutation ($foo: CreateFooInput) {
@@ -52,20 +64,25 @@ func main() {
 			},
 		},
 	}
-	jsonValue, _ := json.Marshal(jsonData)
+	jsonValue, err := json.Marshal(jsonData)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// send the GraphQL request to your Gadget app
-	request, _ := http.NewRequest("POST", "https://<your-gadget-slug>/api/graphql", bytes.NewBuffer(jsonValue))
+	request, err := http.NewRequest("POST", fmt.Sprintf("https://%s.gadget.app/api/graphql", GADGET_APP_SLUG), bytes.NewBuffer(jsonValue))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	request.Header.Set("Content-Type", "application/json")
-	// grab your project's API key from Settings -> API Keys in Gadget
-	request.Header.Set("Authorization", "Bearer <your Gadget API Key>")
+	request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", GADGET_API_KEY))
 
 	// send the request
 	client := &http.Client{Timeout: time.Second * 10}
 	response, err := client.Do(request)
-
 	if err != nil {
-			fmt.Printf("The HTTP request failed with error %s\n", err)
+		log.Fatal(err)
 	}
 	defer response.Body.Close()
 

--- a/packages/go-read-write/read-write-example.go
+++ b/packages/go-read-write/read-write-example.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+func main() {
+	// READ DATA (QUERY)
+	// jsonData := map[string]string{
+	//     "query": `
+	//         { 
+	//             foo(id: 1) {
+	//                 id,
+	//                 bar
+	//             }
+	//         }
+	//     `,
+	// }
+
+
+	// WRITE DATA (MUTATION)
+	jsonData := map[string]interface{}{
+		"query": `
+			mutation ($foo: CreateFooInput) {
+				createFoo(foo: $foo) {
+					success
+					errors {
+						message
+						... on InvalidRecordError {
+							validationErrors {
+								apiIdentifier
+								message
+							}
+						}
+					}
+					foo {
+						id
+						bar
+					}
+				}
+			},
+		
+		`,
+		"variables": map[string]interface{}{
+			"foo": map[string]int{
+				"bar": 1,
+			},
+		},
+	}
+	jsonValue, _ := json.Marshal(jsonData)
+
+	// send the GraphQL request to your Gadget app
+	request, _ := http.NewRequest("POST", "https://<your-gadget-slug>/api/graphql", bytes.NewBuffer(jsonValue))
+	request.Header.Set("Content-Type", "application/json")
+	// grab your project's API key from Settings -> API Keys in Gadget
+	request.Header.Set("Authorization", "Bearer <your Gadget API Key>")
+
+	// send the request
+	client := &http.Client{Timeout: time.Second * 10}
+	response, err := client.Do(request)
+
+	if err != nil {
+			fmt.Printf("The HTTP request failed with error %s\n", err)
+	}
+	defer response.Body.Close()
+
+	// print out the response
+	data, _ := io.ReadAll(response.Body)
+	fmt.Println(string(data))
+}


### PR DESCRIPTION
A very simple example of making a GraphQL request against a Gadget app without the use of our generated npm client API.
You have to go across a couple of pages of docs in order to pull this info together, a short example might be helpful in the future