### PR TITLE
update shopify dependency versions so the bundle app starts

### DIFF
--- a/packages/product-bundles/package.json
+++ b/packages/product-bundles/package.json
@@ -12,8 +12,8 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "3.15.0",
-    "@shopify/cli": "3.15.0"
+    "@shopify/app": "3.21.0",
+    "@shopify/cli": "3.21.0"
   },
   "author": "gadget"
 }


### PR DESCRIPTION
You get a ngrok error when you try to start the bundle app locally using the old cli/app version.
I haven't seen this reported on their Slack or Discord, but it seems like a major issue if old dependency versions fall over