### PR TITLE
Update @gadgetinc/react requirement to 0.8.2 to match app bridge

### DIFF
--- a/packages/nextjs-shopify/package.json
+++ b/packages/nextjs-shopify/package.json
@@ -11,8 +11,8 @@
   },
   "dependencies": {
     "@gadget-client/public-test": "^1.862.0",
-    "@gadgetinc/react": "^0.7.2",
-    "@gadgetinc/react-shopify-app-bridge": "^0.4.0",
+    "@gadgetinc/react": "^0.8.2",
+    "@gadgetinc/react-shopify-app-bridge": "^0.4.3",
     "@shopify/app-bridge-react": "^3.1.1",
     "@shopify/polaris": "^9.21.1",
     "local-ssl-proxy": "^1.3.0",


### PR DESCRIPTION
Currently create-next-app from this example is failing due to mismatched @gadgetinc/react version requirements. 