### PR TITLE
Use latest stable release of nix for CI

### DIFF
--- a/.github/actions/setup-test-env/action.yml
+++ b/.github/actions/setup-test-env/action.yml
@@ -7,8 +7,7 @@ runs:
     steps:
     - uses: cachix/install-nix-action@v15
       with:
-        install_url: https://nixos-nix-install-tests.cachix.org/serve/vij683ly7sl95nnhb67bdjjfabclr85m/install
-        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+        install_url: https://releases.nixos.org/nix/nix-2.11.1/install
     - run: nix flake check
       shell: bash
     - name: Add Gadget yarn registry


### PR DESCRIPTION
@danroberts was running into troubles running CI with the current version of Nix in #89. Getting:

```
> Run nix flake check
error: could not set permissions on '/nix/var/nix/profiles/per-user' to 755: Operation not permitted
Error: Process completed with exit code 1.
```

https://github.com/cachix/install-nix-action/issues/141#issuecomment-1222533694 recommends updating the Nix version, hopefully this will fix it!