### PR TITLE
add middleware to grab shop name for csp header to base Next example

### DIFF
--- a/packages/nextjs-shopify/middleware.ts
+++ b/packages/nextjs-shopify/middleware.ts
@@ -1,0 +1,10 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const shop = request.nextUrl.searchParams.get("shop");
+
+  const response = NextResponse.next();
+  response.headers.set("content-security-policy", `frame-ancestors https://${shop}/ https://admin.shopify.com;`);
+  return response;
+}


### PR DESCRIPTION
Related: https://github.com/gadget-inc/shopify-app-store-product-tagger/pull/3

Shopify requirements: https://shopify.dev/apps/store/security/iframe-protection
Dynamically add the current shop to the response header via Next middleware