### PR TITLE
Add a github job that builds each project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,3 +9,10 @@ jobs:
       - uses: ./.github/actions/setup-test-env
       - name: Lint
         run: nix develop -c yarn lint
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/setup-test-env
+      - name: Test each package
+        run: nix develop -c yarn workspaces run test

--- a/package.json
+++ b/package.json
@@ -14,19 +14,19 @@
     "x": "esbuild-dev --watch=false"
   },
   "workspaces": [
+    "packages/apollo-blog",
+    "pacakges/billing-examples",
     "packages/chakra-theme",
+    "packages/file-upload",
     "packages/login-logout",
+    "packages/margin-calculator",
+    "packages/nextjs-shopify",
+    "packages/product-bundles",
+    "packages/product-recommendations-quiz-app/product-quiz-admin",
+    "packages/shopify-cli-embedded",
     "packages/related-products",
     "packages/simple-blog",
-    "packages/simple-form",
-    "packages/apollo-blog",
-    "packages/file-upload",
-    "packages/margin-calculator",
-    "packages/product-recommendations-quiz-app/product-quiz-admin",
-    "packages/nextjs-shopify",
-    "packages/shopify-cli-embedded",
-    "packages/product-bundles",
-    "pacakges/billing-examples"
+    "packages/simple-form"
   ],
   "dependencies": {
     "@gadgetinc/eslint-config": "^0.4.0",

--- a/packages/apollo-blog/next-env.d.ts
+++ b/packages/apollo-blog/next-env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="next" />
-/// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited

--- a/packages/apollo-blog/package.json
+++ b/packages/apollo-blog/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "next build"
   },
   "dependencies": {
     "@apollo/client": "^3.6.9",

--- a/packages/billing-examples/package.json
+++ b/packages/billing-examples/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "shopify": "shopify",
     "build": "shopify app build",
+    "test": "shopify app build",
     "dev": "shopify app dev --no-update",
     "info": "shopify app info",
     "generate": "shopify app generate",

--- a/packages/chakra-theme/package.json
+++ b/packages/chakra-theme/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "main": "index.ts",
+  "scripts": {
+    "test": "tsc --noEmit"
+  },
   "dependencies": {
     "@chakra-ui/react": "^1.8.8",
     "react": "17.0.2",

--- a/packages/file-upload/package.json
+++ b/packages/file-upload/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "test": "next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/packages/login-logout/package.json
+++ b/packages/login-logout/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "test": "next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/packages/margin-calculator/package.json
+++ b/packages/margin-calculator/package.json
@@ -8,7 +8,8 @@
     "build": "remix build",
     "dev": "remix dev",
     "postinstall": "remix setup node",
-    "start": "remix-serve build"
+    "start": "remix-serve build",
+    "test": "remix build"
   },
   "dependencies": {
     "@gadget-client/margin-calculator-example": "^1.114.0",

--- a/packages/nextjs-shopify/package.json
+++ b/packages/nextjs-shopify/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "next build"
   },
   "dependencies": {
     "@gadget-client/public-test": "^1.862.0",

--- a/packages/product-bundles/package.json
+++ b/packages/product-bundles/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "shopify": "shopify",
     "build": "shopify app build",
+    "test": "shopify app build",
     "dev": "shopify app dev --no-update",
     "info": "shopify app info",
     "generate": "shopify app generate",

--- a/packages/product-recommendations-quiz-app/product-quiz-admin/package.json
+++ b/packages/product-recommendations-quiz-app/product-quiz-admin/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "shopify": "shopify",
     "build": "shopify app build",
+    "test": "shopify app build",
     "dev": "shopify app dev --no-update",
     "info": "shopify app info",
     "generate": "shopify app generate",

--- a/packages/related-products/package.json
+++ b/packages/related-products/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "test": "next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/packages/shopify-cli-embedded/package.json
+++ b/packages/shopify-cli-embedded/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "shopify": "shopify",
     "build": "shopify app build",
+    "test": "shopify app build",
     "dev": "shopify app dev --no-update",
     "info": "shopify app info",
     "scaffold": "shopify app scaffold",

--- a/packages/simple-blog/package.json
+++ b/packages/simple-blog/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "test": "next test",
     "start": "next start",
     "lint": "next lint"
   },

--- a/packages/simple-form/package.json
+++ b/packages/simple-form/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "test": "next test",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Previously, we were relying on vercel to run builds for many projects as a manner of test suite. This makes it a bit more explicit and has github build every project, allowing us to begin to add in more actual tests if we want to each project.