### PR TITLE
fix frontend ports and update to latest CLI version for example apps

### DIFF
--- a/packages/product-bundles/package.json
+++ b/packages/product-bundles/package.json
@@ -13,8 +13,8 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "3.21.0",
-    "@shopify/cli": "3.21.0"
+    "@shopify/app": "^3.39.0",
+    "@shopify/cli": "^3.39.0"
   },
   "author": "gadget"
 }

--- a/packages/product-bundles/web/frontend/package.json
+++ b/packages/product-bundles/web/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "vite build",
-    "dev": "vite & local-ssl-proxy --source 443 --target 3000",
+    "dev": "vite & local-ssl-proxy --source 443 --target 3005",
     "coverage": "vitest run --coverage"
   },
   "type": "module",

--- a/packages/product-bundles/web/frontend/vite.config.js
+++ b/packages/product-bundles/web/frontend/vite.config.js
@@ -1,36 +1,36 @@
 import { defineConfig } from "vite";
 import { dirname } from "path";
 import { fileURLToPath } from "url";
-import https from "https";
 import react from "@vitejs/plugin-react";
 
-if (process.env.npm_lifecycle_event === "build" && !process.env.CI && !process.env.SHOPIFY_API_KEY) {
+if (process.env["npm_lifecycle_event"] === "build" && !process.env["CI"] && !process.env["SHOPIFY_API_KEY"]) {
   console.warn(
     "\nBuilding the frontend app without an API key. The frontend build will not run without an API key. Set the SHOPIFY_API_KEY environment variable when running the build command.\n"
   );
 }
 
-const FRONTEND_PORT = 3000;
-
-const hmrConfig = {
-  protocol: "ws",
-  host: "localhost",
-  port: FRONTEND_PORT,
-  clientPort: FRONTEND_PORT,
-};
+const host = "localhost";
+const port = 3005;
 
 export default defineConfig({
   root: dirname(fileURLToPath(import.meta.url)),
   plugins: [react()],
   define: {
-    "process.env.SHOPIFY_API_KEY": process.env.SHOPIFY_API_KEY,
+    "process.env": JSON.stringify({
+      SHOPIFY_API_KEY: process.env["SHOPIFY_API_KEY"],
+    }),
   },
   resolve: {
     preserveSymlinks: true,
   },
   server: {
-    host: "localhost",
-    port: FRONTEND_PORT,
-    hmr: hmrConfig,
+    host: host,
+    port: port,
+    hmr: {
+      protocol: "ws",
+      host: host,
+      port: port,
+      clientPort: port,
+    },
   },
 });

--- a/packages/product-recommendations-quiz-app/product-quiz-admin/package.json
+++ b/packages/product-recommendations-quiz-app/product-quiz-admin/package.json
@@ -13,8 +13,8 @@
     "deploy": "shopify app deploy"
   },
   "dependencies": {
-    "@shopify/app": "3.23.0",
-    "@shopify/cli": "3.23.0"
+    "@shopify/app": "^3.39.0",
+    "@shopify/cli": "^3.39.0"
   },
   "author": "gadget"
 }

--- a/packages/product-recommendations-quiz-app/product-quiz-admin/web/frontend/package.json
+++ b/packages/product-recommendations-quiz-app/product-quiz-admin/web/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "vite build",
-    "dev": "vite & local-ssl-proxy --source 443 --target 3000",
+    "dev": "vite & local-ssl-proxy --source 443 --target 3005",
     "coverage": "vitest run --coverage"
   },
   "type": "module",

--- a/packages/product-recommendations-quiz-app/product-quiz-admin/web/frontend/vite.config.js
+++ b/packages/product-recommendations-quiz-app/product-quiz-admin/web/frontend/vite.config.js
@@ -5,35 +5,32 @@ import react from "@vitejs/plugin-react";
 
 if (process.env["npm_lifecycle_event"] === "build" && !process.env["CI"] && !process.env["SHOPIFY_API_KEY"]) {
   console.warn(
-    "Building the frontend app without an API key. The frontend build will not run without an API key. Set the SHOPIFY_API_KEY environment variable when running the build command."
+    "\nBuilding the frontend app without an API key. The frontend build will not run without an API key. Set the SHOPIFY_API_KEY environment variable when running the build command.\n"
   );
 }
 
-const FRONTEND_PORT = 3000;
-
-let hmrConfig = {
-  protocol: "ws",
-  host: "localhost",
-  port: FRONTEND_PORT,
-  clientPort: FRONTEND_PORT,
-};
+const host = "localhost";
+const port = 3005;
 
 export default defineConfig({
   root: dirname(fileURLToPath(import.meta.url)),
   plugins: [react()],
   define: {
-    process: {
-      env: {
-        SHOPIFY_API_KEY: process.env["SHOPIFY_API_KEY"],
-      },
-    },
+    "process.env": JSON.stringify({
+      SHOPIFY_API_KEY: process.env["SHOPIFY_API_KEY"],
+    }),
   },
   resolve: {
     preserveSymlinks: true,
   },
   server: {
-    host: "localhost",
-    port: FRONTEND_PORT,
-    hmr: hmrConfig,
+    host: host,
+    port: port,
+    hmr: {
+      protocol: "ws",
+      host: host,
+      port: port,
+      clientPort: port,
+    },
   },
 });


### PR DESCRIPTION
I goofed and didn't update the vite config or port for local-ssl-proxy for the bundle and quiz apps.
Tested out the bundle app with these changes.
The Shopify API version bump is also a blocker - old versions will error out when you try to start them